### PR TITLE
Fix ESM dynamic import failing on Windows

### DIFF
--- a/tools/skill-generator.mjs
+++ b/tools/skill-generator.mjs
@@ -11,7 +11,7 @@
 
 import fs from 'fs/promises';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { readFile } from 'fs/promises';
 import { createHash } from 'crypto';
 import {
@@ -36,8 +36,10 @@ const __dirname = path.dirname(__filename);
 
 async function loadTool(toolName) {
   const toolPath = path.join(__dirname, `${toolName}.mjs`);
+  // ESM import() requires file:// URLs for absolute paths on Windows (C:\... is not valid)
+  const toolUrl = pathToFileURL(toolPath);
   try {
-    const module = await import(toolPath);
+    const module = await import(toolUrl.href);
     return module;
   } catch (error) {
     console.error(`Failed to load tool ${toolName}: ${error.message}`);


### PR DESCRIPTION
## Why

On Windows, `path.join()` produces `C:\...` style paths. Node.js ESM's `import()` rejects these — it requires `file://` URLs for absolute paths. This caused `loadTool()` to silently fail when loading `puppeteer-search` and `arxiv-search`, skipping all web searches (DuckDuckGo, Google Scholar, Wikipedia). The result: generated skills always had 0% quality with no data. The CLI also crashed before printing any output when run directly on Windows.

## Approach

Use Node's built-in `pathToFileURL()` from the `url` module instead of passing the raw path string to `import()`. This is the idiomatic Node.js solution and handles both Windows (`C:\...` → `file:///C:/...`) and Unix (`/unix/path` → `file:///unix/path`) correctly, making the fix cross-platform with no behavior change on Linux/macOS.

## How it works

Two-line change in `loadTool()`:
1. Import `pathToFileURL` from the existing `url` import
2. Convert `toolPath` to a file URL before passing to `import()`

```js
// Before
const module = await import(toolPath);

// After
const toolUrl = pathToFileURL(toolPath);
const module = await import(toolUrl.href);
```

## Reproduction

Run on Windows (Node.js v12+):
```
node tools/skill-generator.mjs "Any Name"
```
Before fix: no output, exits silently, no skill generated.
After fix: full output, web searches execute, skill generated correctly.